### PR TITLE
ENH: add support to VScode locales

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"commands": [
 			{
 				"command": "cslPreview.showCslPreview",
-				"title": "CSL Preview: Show CSL preview",
+				"title": "%cslPreview.showCslPreview.title%",
 				"icon": {
 					"light": "./media/show-preview-inv.svg",
 					"dark": "./media/show-preview.svg"
@@ -41,7 +41,7 @@
 			},
 			{
 				"command": "cslPreview.refreshCslPreview",
-				"title": "CSL Preview: Refresh CSL Preview",
+				"title": "%cslPreview.refreshCslPreview.title%",
 				"icon": {
 					"light": "./media/refresh-preview-inv.svg",
 					"dark": "./media/refresh-preview.svg"
@@ -49,7 +49,7 @@
 			},
 			{
 				"command": "cslPreview.showPreviewSource",
-				"title": "CSL Preview: Show source",
+				"title": "%cslPreview.showPreviewSource.title%",
 				"icon": {
 					"light": "./media/view-source-inv.svg",
 					"dark": "./media/view-source.svg"

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,0 +1,14 @@
+{
+    "products.installingModule": "Installing {0}",
+    "cslPreview.showCslPreview.title": "CSL Preview: Show CSL preview",
+    "cslPreview.refreshCslPreview.title": "CSL Preview: Refresh Csl Preview",
+    "cslPreview.showPreviewSource.title": "CSL Preview: Show source",
+    "askCitablesSourceText": "Open CSL citations and bibliography preview using citables from: ",
+    "citablesSrcOpts": {
+        "stdDocs":"Standard documents",
+        "doi": "DOI"
+    },
+    "common.Bibliography": "Bibliography",
+    "common.indCitations": "Individual citations",
+    "common.uniqCitation": "Unique citation"
+}

--- a/package.nls.pt-br.json
+++ b/package.nls.pt-br.json
@@ -1,0 +1,14 @@
+{
+    "products.installingModule": "Instalando {0}",
+    "cslPreview.showCslPreview.title": "CSL Preview: Mostrar previsualização do estilo",
+    "cslPreview.refreshCslPreview.title": "CSL Preview: Atualizar previsualização do estilo",
+    "cslPreview.showPreviewSource.title": "CSL Preview: mostrar código-fonte",
+    "askCitablesSourceText": "Visualizar prévia das citações e bibliografia usando citáveis de: ",
+    "citablesSrcOpts": {
+        "stdDocs":"Documentos padrão",
+        "doi": "DOI"
+    },
+    "common.Bibliography": "Bibliografia",
+    "common.indCitations": "Citações individuais",
+    "common.uniqCitation": "Citação única"
+}

--- a/src/csl-engine.js
+++ b/src/csl-engine.js
@@ -1,5 +1,6 @@
 const CSL = require('citeproc');
 const fs = require('fs');
+const dict = require('./nls');
 
 module.exports = class CSLEngine{
     constructor(extensionPath){
@@ -64,11 +65,11 @@ class CiteprocSys{
 }
 
 function formatHtmlPreview(individualCitations, uniqueCitation, bibliography){
-    let html = '<h3>Individual citations</h3><hr>';
+    let html = `<h3>${dict['common.indCitations']}</h3><hr>`;
     html += '<p>' + individualCitations.join('<br>') + '</p>';
-    html += '<h3>Unique citation</h3><hr>';
+    html += `<h3>${dict['common.uniqCitation']}</h3><hr>`;
     html += '<p>' + uniqueCitation[1][0][1] + '</p>';
-    html += '<h3>Bibliography</h3><hr>';
+    html += `<h3>${dict['common.Bibliography']}</h3><hr>`;
     html += bibliography;
     return html
 }

--- a/src/extension-commander.js
+++ b/src/extension-commander.js
@@ -1,5 +1,6 @@
 const vscode = require('vscode');
 const utils = require('./utils');
+const dict = require('./nls')
 
 module.exports = class ExtensionCommander{
     constructor(manager){
@@ -8,14 +9,14 @@ module.exports = class ExtensionCommander{
     showCslPreview(){
         let editor = vscode.window.activeTextEditor;
         if(!this.manager.doesDocumentHasPreview(editor.document)){
-            let text = 'Open CSL citations and bibliography preview using citables from: '
-            let options = ['Standard documents', 'DOI'];
+            let text = dict['askCitablesSourceText'];
+            let options = Object.values(dict.citablesSrcOpts);
             let pick = vscode.window.showQuickPick(options,{placeHolder: text});
             pick.then(input => {
                 if(input != undefined){
-                    if (input == 'Standard documents'){
+                    if (input == dict.citablesSrcOpts.stdDocs){
                         this.openCslPreviewFromJson();
-                    }else if(input == 'DOI'){
+                    }else if(input == dict.citablesSrcOpts.doi){
                         this.openCslPreviewFromIdentifier();
                     }
                 }

--- a/src/nls.js
+++ b/src/nls.js
@@ -1,0 +1,27 @@
+const vscode = require('vscode');
+const fs = require('fs');
+const path = require('path');
+
+function filterLocales(path){
+    let langs = []
+    let paths = fs.readdirSync(extensionPath)
+        .filter((str)=>{if(str.includes('.nls.')) return true});
+    for(let i = 0; i < paths.length; i++){
+        if(paths[i].split('.').length == 4){
+            langs.push(paths[i].split('.')[2])
+        }
+    }
+    return langs
+}
+
+let extensionPath = path.resolve(__dirname, '../');
+let langs = filterLocales(extensionPath);
+
+let lang = vscode.env.language;
+let nls
+if(lang == 'en-us' || !langs.includes(lang)){
+    nls = '/package.nls.json';
+}else{
+    nls = '/package.nls.' + lang + '.json';
+}
+module.exports = JSON.parse(fs.readFileSync(extensionPath + nls).toString('utf-8'));

--- a/src/preview-controller.js
+++ b/src/preview-controller.js
@@ -20,6 +20,7 @@ module.exports = class PreviewController{
             this.editor = null;
             this.manager.disposeController(this);
             this.onDidChangeActiveEditor(vscode.window.activeTextEditor);
+            vscode.commands.executeCommand('setContext', 'CSLPreviewActive', false);
         })
         vscode.window.onDidChangeActiveTextEditor((textEditor) => {
             this.onDidChangeActiveEditor(textEditor);


### PR DESCRIPTION
This PR provides support for VSCode Locales, turning the extension able to present its commands in the idiom selected by the user in VSCode (when the extension provides the respective locale support). This PR also implements the Brazilian Portuguese (pt-br) locale, which can be used as an example for contributors who want to add their native language to the extension.

To add a new locale the contributor must create a package.nls.IDIOM.json file whereas IDIOM refers to the code of the idiom being implemented.