### PR TITLE
ENH: CSL locale choose implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 			},
 			{
 				"command": "cslPreview.chooseLocale",
-				"title": "CSL Preview: Choose Locale"
+				"title": "%cslPreview.chooseLocale.title%"
 			}
 		],
 		"menus": {
@@ -96,7 +96,7 @@
 				},
 				{
 					"command": "cslPreview.chooseLocale",
-					"title": "CSL Preview: Choose Locale",
+					"title": "%cslPreview.chooseLocale.title%",
 					"group": "navigation"
 				}
 			]

--- a/package.json
+++ b/package.json
@@ -54,6 +54,10 @@
 					"light": "./media/view-source-inv.svg",
 					"dark": "./media/view-source.svg"
 				}
+			},
+			{
+				"command": "cslPreview.chooseLocale",
+				"title": "CSL Preview: Choose Locale"
 			}
 		],
 		"menus": {
@@ -88,6 +92,11 @@
 				{
 					"command": "cslPreview.refreshCslPreview",
 					"when": "CSLPreviewActive || cslSourceActive",
+					"group": "navigation"
+				},
+				{
+					"command": "cslPreview.chooseLocale",
+					"title": "CSL Preview: Choose Locale",
 					"group": "navigation"
 				}
 			]

--- a/package.nls.json
+++ b/package.nls.json
@@ -3,7 +3,7 @@
     "cslPreview.showCslPreview.title": "CSL Preview: Show CSL preview",
     "cslPreview.refreshCslPreview.title": "CSL Preview: Refresh Csl Preview",
     "cslPreview.showPreviewSource.title": "CSL Preview: Show source",
-    "cslPreview.chooseLocale.title": "CSL Preview: Choose Locale",
+    "cslPreview.chooseLocale.title": "CSL Preview: Choose preview Locale",
     "askCitablesSourceText": "Open CSL citations and bibliography preview using citables from: ",
     "citablesSrcOpts": {
         "stdDocs":"Standard documents",

--- a/package.nls.json
+++ b/package.nls.json
@@ -3,6 +3,7 @@
     "cslPreview.showCslPreview.title": "CSL Preview: Show CSL preview",
     "cslPreview.refreshCslPreview.title": "CSL Preview: Refresh Csl Preview",
     "cslPreview.showPreviewSource.title": "CSL Preview: Show source",
+    "cslPreview.chooseLocale.title": "CSL Preview: Choose Locale",
     "askCitablesSourceText": "Open CSL citations and bibliography preview using citables from: ",
     "citablesSrcOpts": {
         "stdDocs":"Standard documents",
@@ -10,5 +11,6 @@
     },
     "common.Bibliography": "Bibliography",
     "common.indCitations": "Individual citations",
-    "common.uniqCitation": "Unique citation"
+    "common.uniqCitation": "Unique citation",
+    "localeSelectDialog": "Choose language RFC 5646 tag of desired locale"
 }

--- a/package.nls.pt-br.json
+++ b/package.nls.pt-br.json
@@ -3,7 +3,7 @@
     "cslPreview.showCslPreview.title": "CSL Preview: Mostrar previsualização do estilo",
     "cslPreview.refreshCslPreview.title": "CSL Preview: Atualizar previsualização do estilo",
     "cslPreview.showPreviewSource.title": "CSL Preview: mostrar código-fonte",
-    "cslPreview.chooseLocale.title": "CSL Preview: Escolher idioma",
+    "cslPreview.chooseLocale.title": "CSL Preview: Escolher idioma da previsualização",
     "askCitablesSourceText": "Visualizar prévia das citações e bibliografia usando citáveis de: ",
     "citablesSrcOpts": {
         "stdDocs":"Documentos padrão",

--- a/package.nls.pt-br.json
+++ b/package.nls.pt-br.json
@@ -3,6 +3,7 @@
     "cslPreview.showCslPreview.title": "CSL Preview: Mostrar previsualização do estilo",
     "cslPreview.refreshCslPreview.title": "CSL Preview: Atualizar previsualização do estilo",
     "cslPreview.showPreviewSource.title": "CSL Preview: mostrar código-fonte",
+    "cslPreview.chooseLocale.title": "CSL Preview: Escolher idioma",
     "askCitablesSourceText": "Visualizar prévia das citações e bibliografia usando citáveis de: ",
     "citablesSrcOpts": {
         "stdDocs":"Documentos padrão",
@@ -10,5 +11,6 @@
     },
     "common.Bibliography": "Bibliografia",
     "common.indCitations": "Citações individuais",
-    "common.uniqCitation": "Citação única"
+    "common.uniqCitation": "Citação única",
+    "localeSelectDialog": "Escolher tag RFC 5646 do idioma desejado"
 }

--- a/src/csl-engine.js
+++ b/src/csl-engine.js
@@ -8,6 +8,8 @@ module.exports = class CSLEngine{
         this.citeprocSys = new CiteprocSys(this);
         this.citables = null;
         this.citablesIds = null;
+        this.lang = null;
+        this.forcedLang = null;
     }
     updateCitables(citables){
         this.citables = citables;
@@ -20,7 +22,7 @@ module.exports = class CSLEngine{
         return errors
     }
     buildProcessor(style){
-        this.proc = new CSL.Engine(this.citeprocSys, style);
+        this.proc = new CSL.Engine(this.citeprocSys, style, this.forcedLang, this.forcedLang);
         this.proc.updateItems(this.citablesIds);
     }
     buildPreviewContent(style){
@@ -54,6 +56,7 @@ class CiteprocSys{
         this.engine = engine;
     }
     retrieveLocale(lang){
+        this.engine.lang = lang;
         let path = this.engine.extensionPath + '/src/resources/locales/';
         let file = 'locales-' + lang + '.xml';
         return fs.readFileSync(path + file).toString('utf-8');

--- a/src/extension-commander.js
+++ b/src/extension-commander.js
@@ -1,5 +1,6 @@
 const vscode = require('vscode');
 const utils = require('./utils');
+const locales = require('./resources/locales/locales.json');
 
 module.exports = class ExtensionCommander{
     constructor(manager){
@@ -54,5 +55,17 @@ module.exports = class ExtensionCommander{
             controller = this.manager.getControllerFromActiveWebview();
         }
         controller.refreshPreview();
+    }
+    chooseLocale(){
+        let active_controler = this.manager.getActiveController();
+        let codes = Object.keys(locales['language-names']);
+        let text = "Choose language RFC 5646 tag of desired locale";
+        let pick = vscode.window.showQuickPick(codes, {placeHolder:text});
+        pick.then(input =>{
+            if (input != undefined){
+                active_controler.engine.forcedLang = input;
+                active_controler.refreshPreview();
+            }
+        })
     }
 }

--- a/src/extension.js
+++ b/src/extension.js
@@ -1,6 +1,7 @@
 const vscode = require('vscode');
 const PreviewManager = require('./previews-manager');
 const ExtensionCommander = require('./extension-commander');
+const LocaleBar = require('./locale-bar');
 
 /**
  * @param {vscode.ExtensionContext} context
@@ -8,12 +9,14 @@ const ExtensionCommander = require('./extension-commander');
 
 function activate(context) {
 	const register = vscode.commands.registerCommand;
-	const manager = new PreviewManager(context.extensionPath);
+	const localeBar = new LocaleBar(context.extensionPath);
+	const manager = new PreviewManager(context.extensionPath, localeBar);
 	const commander = new ExtensionCommander(manager);
 	context.subscriptions.push(
 		register('cslPreview.showCslPreview', () => commander.showCslPreview()),
 		register('cslPreview.refreshCslPreview', () => commander.refreshPreview()),
-		register('cslPreview.showPreviewSource', () => commander.showSource())
+		register('cslPreview.showPreviewSource', () => commander.showSource()),
+		register('cslPreview.chooseLocale', () => commander.chooseLocale())
 	);
 }
 exports.activate = activate;

--- a/src/locale-bar.js
+++ b/src/locale-bar.js
@@ -1,10 +1,12 @@
 const vscode = require('vscode');
+const dict = require('./nls')
 
 module.exports = class LocaleBar{
     constructor(extensionPath){
         this.extensionPath = extensionPath;
         this.bar = vscode.window.createStatusBarItem(2, 10000);
-        this.bar.text = "$(ports-open-browser-icon)"
-        this.bar.command = 'cslPreview.chooseLocale'
+        this.bar.text = "$(ports-open-browser-icon)";
+        this.bar.command = 'cslPreview.chooseLocale';
+        this.bar.tooltip = dict['cslPreview.chooseLocale.title'];
     }
 }

--- a/src/locale-bar.js
+++ b/src/locale-bar.js
@@ -1,0 +1,10 @@
+const vscode = require('vscode');
+
+module.exports = class LocaleBar{
+    constructor(extensionPath){
+        this.extensionPath = extensionPath;
+        this.bar = vscode.window.createStatusBarItem(2, 10000);
+        this.bar.text = "$(ports-open-browser-icon)"
+        this.bar.command = 'cslPreview.chooseLocale'
+    }
+}

--- a/src/preview-controller.js
+++ b/src/preview-controller.js
@@ -7,12 +7,13 @@ module.exports = class PreviewController{
         this.manager = manager;
         this.editor = textEditor,
         this.engine = new CSLEngine(this.manager.extensionPath);
-        this.panel = new PreviewPanel();
+        this.panel = new PreviewPanel(this);
         //callbacks
         vscode.workspace.onDidCloseTextDocument((textDocument) => {
             if (textDocument === this.editor.document){
                 this.panel.view.dispose();
             }
+            this.manager.refreshLocaleBar();
         })
         this.panel.view.onDidDispose(()=>{
             this.engine = null;
@@ -29,6 +30,7 @@ module.exports = class PreviewController{
         let style = this.editor.document.getText().toString();
         let bib = this.engine.buildPreviewContent(style);
         this.panel.updateContentHtml(bib);
+        this.manager.refreshLocaleBar();
     }
     onDidChangeActiveEditor(textEditor){
         if(textEditor != undefined){
@@ -41,5 +43,9 @@ module.exports = class PreviewController{
         }else{
             vscode.commands.executeCommand('setContext', 'cslSourceActive', false);
         }
+        this.manager.refreshLocaleBar();
+    }
+   onDidChangeActiveWebview(){
+        this.manager.refreshLocaleBar();
     }
 }

--- a/src/preview-panel.js
+++ b/src/preview-panel.js
@@ -1,10 +1,11 @@
 const vscode = require('vscode');
 
 module.exports = class PreviewPanel{
-    constructor(){
+    constructor(controller){
         let fileName = vscode.window.activeTextEditor.document.fileName.split('/');
         let viewName = 'Preview ' + fileName[fileName.length - 1];
         let column = vscode.window.activeTextEditor.viewColumn + 1;
+        this.controller = controller;
         this.view = vscode.window.createWebviewPanel(
             'CSLPreview',
             viewName,
@@ -13,6 +14,7 @@ module.exports = class PreviewPanel{
         )
         this.view.onDidChangeViewState(({webviewPanel}) => {
             vscode.commands.executeCommand('setContext', 'CSLPreviewActive', webviewPanel.active);
+            this.controller.onDidChangeActiveWebview();
         })
         vscode.commands.executeCommand('setContext', 'CSLPreviewActive', true);
     }

--- a/src/previews-manager.js
+++ b/src/previews-manager.js
@@ -2,9 +2,10 @@ const PreviewController = require('./preview-controller');
 const vscode = require('vscode');
 
 module.exports = class PreviewManager{
-    constructor(extensionPath){
+    constructor(extensionPath, localeBar){
         this.extensionPath = extensionPath;
         this.controllers = [];
+        this.localeBar = localeBar;
     }
     createController(citables){
         let editor = vscode.window.activeTextEditor;
@@ -12,6 +13,7 @@ module.exports = class PreviewManager{
         _controller.engine.updateCitables(citables);
         _controller.refreshPreview();
         this.controllers.push(_controller);
+        this.refreshLocaleBar();
     }   
     disposeController(_controller){
         let index = this.controllers.indexOf(_controller);
@@ -25,5 +27,28 @@ module.exports = class PreviewManager{
     }
     getControllerFromActiveWebview(){
         return this.controllers.find(controller => controller.panel.view.active == true)
+    }
+    getActiveController(){
+        let doc = undefined
+        if (vscode.window.activeTextEditor != undefined){
+            doc = this.getControllerFromDocument(vscode.window.activeTextEditor.document);
+        }
+        let view = this.getControllerFromActiveWebview();
+        if (view != undefined){
+            return view     
+        }else if(doc != undefined){
+            return doc
+        }else{
+            return undefined
+        }
+    }
+    refreshLocaleBar(){
+        let active_controller = this.getActiveController();
+        if(active_controller != undefined){
+            this.localeBar.bar.text = "$(ports-open-browser-icon) " + active_controller.engine.lang;
+            this.localeBar.bar.show();
+        }else{
+            this.localeBar.bar.hide();
+        }
     }
 }


### PR DESCRIPTION
This PR implements a command to permit the user to select the desired CSL locale in the style preview. At the point of this PR the available locales are those provided in citation-style-language/locales repository.

This PR also implements a VSCode status bar item which will show the current locale being presented in the style preview and trigger the command to select locale when mouse clicked.