### PR TITLE
[ENH] Provide configuration options to user define its default locale and citables file

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,21 @@
 				"title": "%cslPreview.chooseLocale.title%"
 			}
 		],
+		"configuration":{
+			"title": "CSL Preview",
+			"properties": {
+				"cslPreview.defaultCitablesFilePath": {
+					"type": "string",
+					"default": "",
+					"description": "%cslPreview.defaultCitablesFilePath.title%"
+				},
+				"cslPreview.defaultLocale": {
+					"type": "string",
+					"default": "",
+					"description": "%cslPreview.defaultLocale%"
+				}
+			}
+		},
 		"menus": {
 			"editor/title": [
 				{

--- a/package.nls.json
+++ b/package.nls.json
@@ -4,12 +4,16 @@
     "cslPreview.refreshCslPreview.title": "CSL Preview: Refresh Csl Preview",
     "cslPreview.showPreviewSource.title": "CSL Preview: Show source",
     "cslPreview.chooseLocale.title": "CSL Preview: Choose preview Locale",
+    "cslPreview.defaultCitablesFilePath.title": "Path for a citables JSON file that will be default when choosing Standard Documents option",
+    "cslPreview.defaultLocale": "Locale to be selected as default in preview windows (e.g. en-US)",
     "askCitablesSourceText": "Open CSL citations and bibliography preview using citables from: ",
     "citablesSrcOpts": {
         "stdDocs":"Standard documents",
         "doi": "DOI",
         "selCslJson": "Select CSL JSON file"
     },
+    "invalidDocsJsonMsg": "Invalid path for citables JSON file set in configuration",
+    "invalidConfLocaleMsg": "Invalid default locale set in configuration",
     "common.Bibliography": "Bibliography",
     "common.indCitations": "Individual citations",
     "common.uniqCitation": "Unique citation",

--- a/package.nls.pt-br.json
+++ b/package.nls.pt-br.json
@@ -4,12 +4,16 @@
     "cslPreview.refreshCslPreview.title": "CSL Preview: Atualizar previsualização do estilo",
     "cslPreview.showPreviewSource.title": "CSL Preview: mostrar código-fonte",
     "cslPreview.chooseLocale.title": "CSL Preview: Escolher idioma da previsualização",
+    "cslPreview.defaultCitablesFilePath.title": "Caminho para um arquivo JSON com citáveis que será padrão quando selecionada a opção Documentos Padrão",
+    "cslPreview.defaultLocale": "Idioma para ser selecionado como padrão nas janelas de previsualização (ex. pt-BR)",
     "askCitablesSourceText": "Visualizar prévia das citações e bibliografia usando citáveis de: ",
     "citablesSrcOpts": {
         "stdDocs":"Documentos padrão",
         "doi": "DOI",
         "selCslJson": "Selecionar arquivo CSL JSON"
     },
+    "invalidDocsJsonMsg": "Caminho inválido para arquivo JSON com citáveis definido nas configurações",
+    "invalidConfLocaleMsg": "Idioma padrão inválido definido nas configurações",
     "common.Bibliography": "Bibliografia",
     "common.indCitations": "Citações individuais",
     "common.uniqCitation": "Citação única",

--- a/src/extension-commander.js
+++ b/src/extension-commander.js
@@ -3,6 +3,10 @@ const utils = require('./utils');
 const locales = require('./resources/locales/locales.json');
 const dict = require('./nls')
 
+const conf = () => {
+    return vscode.workspace.getConfiguration('cslPreview');
+}
+
 module.exports = class ExtensionCommander{
     constructor(manager){
         this.manager = manager;
@@ -16,7 +20,18 @@ module.exports = class ExtensionCommander{
             pick.then(input => {
                 if(input != undefined){
                     if (input == dict.citablesSrcOpts.stdDocs){
-                        this.openCslPreviewFromJson();
+                        let path = conf().get('defaultCitablesFilePath');
+                        if(path != ""){
+                            try{
+                                let input = vscode.Uri.file(path);
+                                this.openCslPreviewFromJson(input);
+                            }catch(e){
+                                vscode.window.showInformationMessage(dict.invalidDocsJsonMsg);
+                                this.openCslPreviewFromJson();
+                            }
+                        }else{
+                            this.openCslPreviewFromJson();
+                        }
                     }else if(input == dict.citablesSrcOpts.selCslJson){
                         let path = vscode.window.showOpenDialog({
                             canSelectFiles: true,
@@ -28,7 +43,7 @@ module.exports = class ExtensionCommander{
                             title: "Select CSL JSON file"
                         })
                         path.then(input =>{
-                            this.openCslPreviewFromJson(input);
+                            this.openCslPreviewFromJson(input[0]);
                         })
                     }else if(input == dict.citablesSrcOpts.doi){
                         this.openCslPreviewFromIdentifier();
@@ -47,7 +62,7 @@ module.exports = class ExtensionCommander{
             path = this.manager.extensionPath + '/src/resources/example_items.json';
             citables = utils.getCitablesFromJson(path);
         }else{
-            path = input[0].path.slice(1)
+            path = input.path.slice(1)
             citables = utils.getCitablesFromJson(path);     
         }
         this.manager.createController(citables);

--- a/src/previews-manager.js
+++ b/src/previews-manager.js
@@ -1,5 +1,7 @@
 const PreviewController = require('./preview-controller');
 const vscode = require('vscode');
+const locales = require('./resources/locales/locales.json');
+const dict = require('./nls');
 
 module.exports = class PreviewManager{
     constructor(extensionPath, localeBar){
@@ -10,6 +12,14 @@ module.exports = class PreviewManager{
     createController(citables){
         let editor = vscode.window.activeTextEditor;
         let _controller = new PreviewController(this, editor);
+        let lang = vscode.workspace.getConfiguration('cslPreview').get('defaultLocale');
+        if(lang != ''){
+            if(lang in locales['language-names']){
+                _controller.engine.forcedLang = lang;
+            }else{
+                vscode.window.showInformationMessage(dict.invalidConfLocaleMsg);
+            }
+        }
         _controller.engine.updateCitables(citables);
         _controller.refreshPreview();
         this.controllers.push(_controller);


### PR DESCRIPTION
This PR provides extensions configurations that will provide the users the possibility to define:

- a custom default citables source file from which the documents shown in the previews opened with the option "Standard documents" are taken;
- the default locale that will be displayed in the preview when the preview window is opened.
