### PR TITLE
Fixed bibliography paths broken due to input.path.slice(1) on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ There is no know issues at the moment. If you experience trobles when using the 
 
 ## Release Notes
 
+### 0.2.3
+
+* Fixes a bug with bibliography json-files on Linux
+
 ### 0.2.2
 
 * Fixes [issue 12](https://github.com/igorjrd/vscode-cslpreview/issues/12)

--- a/src/extension-commander.js
+++ b/src/extension-commander.js
@@ -62,7 +62,7 @@ module.exports = class ExtensionCommander{
             path = this.manager.extensionPath + '/src/resources/example_items.json';
             citables = utils.getCitablesFromJson(path);
         }else{
-            path = input.path.slice(1)
+            path = input.fsPath;
             citables = utils.getCitablesFromJson(path);     
         }
         this.manager.createController(citables);


### PR DESCRIPTION
On version 0.2.2, custom bibliographies cannot be opened from json-files on Linux. When you choose a json-file from the file picker, the root slash is removed ("/home/username/data.json -> home/username/data.json). This fixes the issue.